### PR TITLE
Add loop toggle

### DIFF
--- a/Sonification/MicroRhythm/index.html
+++ b/Sonification/MicroRhythm/index.html
@@ -28,6 +28,10 @@
                 <label for="play-toggle">Play</label>
                 <span id="play-toggle"></span>
             </div>
+            <div class="controller-container" title="Enable playback looping">
+                <label for="loop-toggle">Loop</label>
+                <span id="loop-toggle"></span>
+            </div>
             <div class="controller-container" title="Enable periodic click sound">
                 <label for="click-toggle">Click</label>
                 <span id="click-toggle"></span>


### PR DESCRIPTION
This PR modifies the `repeatTimer` behavior. Now renamed to `cycleEndTimer`, when reaching the end of playback phase, it will either repeat the playback (as before) or stop and clear the playback state, depending on the Loop toggle state set any time (even during playback) by the user.