### PR TITLE
App name etc

### DIFF
--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -286,7 +286,13 @@ const app = new Vue({
         updateTracker() {
             if (this.playing) {
                 let cyclePos = csound.RequestChannel('phase');
-                let dataTime = scale(cyclePos, this.timeAttrRange.max, this.timeAttrRange.min);
+                // For obscure reasons CODAP Time is measured in seconds,
+                // not milliseconds. Normally this adjustment is automatic.
+                // In order for the sonification tracker to align with the
+                // data we need to take this obscurity into account
+                let timeAdj = this.state.timeAttrIsDate? 1000: 1;
+                let dataTime = scale(cyclePos,
+                    this.timeAttrRange.max/timeAdj, this.timeAttrRange.min/timeAdj);
                 helper.setGlobal(trackingGlobalName, dataTime);
             }
         },

--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -41,7 +41,8 @@ const pitchMIDIRange = maxPitchMIDI - minPitchMIDI;
 const app = new Vue({
     el: '#app',
     data: {
-        name: 'Micro Rhythm',
+        name: 'Sonify',
+        version: 'v0.2.0',
         dim: {
             width: 325,
             height: 274
@@ -700,7 +701,7 @@ const app = new Vue({
         this.setupDrag();
         this.setupUI();
 
-        helper.init(this.name, this.dim)
+        helper.init(this.name, this.dim, this.version)
             // .then(helper.monitorLogMessages.bind(helper))
             .then((state) => {
                 if (state) {


### PR DESCRIPTION
This PR has three small changes
1. Renamed the plugin to "Sonify". This is just a candidate name, since there wasn't a consensus, but it is clearer than MicroRhythm.
2. Added version. Set it to 0.2.0.
3. Fixed the bug Bill discovered: that tracking doesn't work when the time value is a Date object.