### PR TITLE
Remove 'descending' checkbox

### DIFF
--- a/Sonification/MicroRhythm/index.html
+++ b/Sonification/MicroRhythm/index.html
@@ -76,9 +76,9 @@
                 <label title="Whether the attribute controlling pitch has date/time values or is numeric">
                     <input type="checkbox" v-model="state.pitchAttrIsDate" v-on:change="onPitchAttributeSelectedByUI"> DateTime
                 </label>
-                <label title="Whether to pitch should descend or ascend when attribute increases">
-                    <input type="checkbox" v-model="state.pitchAttrIsDescending" v-on:change="onPitchAttributeSelectedByUI"> Descending
-                </label>
+<!--                <label title="Whether to pitch should descend or ascend when attribute increases">-->
+<!--                    <input type="checkbox" v-model="state.pitchAttrIsDescending" v-on:change="onPitchAttributeSelectedByUI"> Descending-->
+<!--                </label>-->
             </div>
         </div>
 


### PR DESCRIPTION
Removes from UI only. The underlying capability persists.