### PR TITLE
Work

### DIFF
--- a/Sonification/MicroRhythm/SinusoidalGrains.csd
+++ b/Sonification/MicroRhythm/SinusoidalGrains.csd
@@ -4,8 +4,8 @@
 </CsOptions>
 <CsInstruments>
 sr = 44100
-ksmps = 200
-nchnls = 2
+ksmps = 200   ; samples per second
+nchnls = 2    ; number or channels
 0dbfs = 1.0
 
 zakinit 2, 1
@@ -17,19 +17,22 @@ gkfreq init 1
 gktrig init 0
 turnon "MASTER"
 
+; The MASTER Instrument sets up the metronome, which, in turn causes the
+; continuous repeat
 instr MASTER
-kfreq chnget "playbackSpeed"
+kfreq chnget "playbackSpeed" ; playbackSpeed is set by app and is a number between 0 and 1.
 gkfreq = expcurve(kfreq, 50)
 gkfreq = expcurve(gkfreq, 50)
-gkfreq = scale(gkfreq, 25, 0.1)
-gktrig = metro(gkfreq)
+gkfreq = scale(gkfreq, 5, 0.05) ; scales gkfreq to be within .05 and 5
+gktrig = metro(gkfreq) ; generates a pulse at an interval: 0 0 0 0 1 0 0 0 0 0 1
 
-gkclick chnget "click"
+gkclick chnget "click" ; click is set by app and is either 0 or 1
 if gkclick == 1 then
     schedkwhen gktrig, 0, 0, "CLICK", 0, 0.05
 endif
 endin
 
+; The TRIG Instrument schedules GRAIN instrument events.
 instr 1, TRIG
 kdelay = p4 * 1/gkfreq
 kdur = scale(p5, 0.5, 0.02)
@@ -39,10 +42,13 @@ kpan = p8
 schedkwhen gktrig, 0, 0, "GRAIN", kdelay, kdur, kpitch, kgain, kpan
 endin
 
+; Unknown invocation
 instr 2, KILL
 turnoff2 "GRAIN", 0, 1
+
 endin
 
+; The GRAIN Instrument actually creates sounds
 instr 3, GRAIN
 iatk = 0.002
 igain = p5 * 0.075
@@ -57,12 +63,15 @@ zawm asigL * iverbsend, giverbchL
 zawm asigR * iverbsend, giverbchR
 endin
 
+; The CLICK instrument creates a click event every time the metronome triggers
+; a restart
 instr 4, CLICK
 aenv = expseg(0.2, p3, 0.001)
 asig noise aenv, 0
 outs asig, asig
 endin
 
+; The VERB instrument creates a bit of reverb
 instr +VERB
 asigL zar giverbchL
 asigR zar giverbchR

--- a/Sonification/MicroRhythm/SinusoidalGrains.csd
+++ b/Sonification/MicroRhythm/SinusoidalGrains.csd
@@ -30,6 +30,9 @@ gkclick chnget "click" ; click is set by app and is either 0 or 1
 if gkclick == 1 then
     schedkwhen gktrig, 0, 0, "CLICK", 0, 0.05
 endif
+
+kphase phasor gkfreq, 0
+chnset kphase, "phase"
 endin
 
 ; The TRIG Instrument schedules GRAIN instrument events.

--- a/Sonification/MicroRhythm/StableGrains.csd
+++ b/Sonification/MicroRhythm/StableGrains.csd
@@ -8,13 +8,14 @@ ksmps = 200   ; control rate in samples per second
 nchnls = 2    ; number or channels
 0dbfs = 1.0
 
-zakinit 2, 1
-gimixchL = 1
-gimixchR = 2
+zakinit 1, 1
+gimixch = 1
 turnon "MIX"
 
 gkfreq init 1
 gktrig init 0
+
+gisaw ftgen 1, 0, 16384, 7, -1, 16384, 1
 
 ; The MASTER Instrument sets up the metronome and phasor
 instr 1, MASTER
@@ -33,23 +34,26 @@ if gkclick == 1 then
 endif
 endin
 
-; The GRAIN Instrument actually creates sounds
-instr 2, GRAIN
+; The SOFT Instrument actually creates sounds
+instr 2, SOFT
 iatk = 0.002
 igain = p5 * 0.075
-ipan = p6
 aenv = madsr:a(iatk, p3-iatk, 0, 0) * igain
 asig oscil aenv, cpsmidinn(scale(p4,110,55))
-asigL, asigR pan2 asig, ipan
-; outs asigL, asigR
+zawm asig, gimixch
+endin
 
-zawm asigL, gimixchL
-zawm asigR, gimixchR
+instr 3, HARD
+iatk = 0.002
+igain = p5 * 0.025
+aenv = madsr:a(iatk, p3-iatk, 0, 0) * igain
+asig oscil aenv, cpsmidinn(scale(p4,110,55)), 1
+zawm asig, gimixch
 endin
 
 ; The CLICK instrument creates a click event every time the metronome triggers
 ; a restart
-instr 3, CLICK
+instr 4, CLICK
 aenv = expseg(0.2, p3, 0.001)
 asig noise aenv, 0
 outs asig, asig
@@ -57,16 +61,15 @@ endin
 
 ; The MIX channel aggregates and limits the output volume.
 instr +MIX
-asigL zar gimixchL
-asigR zar gimixchR
-zacl gimixchL, gimixchR
+asig zar gimixch
+zacl 0, gimixch
 
-asigL limit asigL, -1, 1
-asigR limit asigR, -1, 1
-outs asigL, asigR
+asig limit asig, -1, 1
+outs asig, asig
 endin
 
 </CsInstruments>
 <CsScore>
+f0 36000
 </CsScore>
 </CsoundSynthesizer>

--- a/Sonification/MicroRhythm/StableGrains.csd
+++ b/Sonification/MicroRhythm/StableGrains.csd
@@ -1,0 +1,72 @@
+<CsoundSynthesizer>
+<CsOptions>
+-odac -d
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 200   ; control rate in samples per second
+nchnls = 2    ; number or channels
+0dbfs = 1.0
+
+zakinit 2, 1
+gimixchL = 1
+gimixchR = 2
+turnon "MIX"
+
+gkfreq init 1
+gktrig init 0
+
+; The MASTER Instrument sets up the metronome and phasor
+instr 1, MASTER
+kfreq chnget "playbackSpeed" ; playbackSpeed is set by app and is a number between 0 and 1.
+gkfreq = expcurve(kfreq, 50)
+gkfreq = expcurve(gkfreq, 50)
+gkfreq = scale(gkfreq, 5, 0.05) ; scales gkfreq to be within .05 and 5
+
+kphase phasor gkfreq, p4
+chnset kphase, "phase"
+
+gktrig = metro(gkfreq, p4) ; generates a pulse at an interval: 0 0 0 0 1 0 0 0 0 0 1
+gkclick chnget "click" ; click is set by app and is either 0 or 1
+if gkclick == 1 then
+    schedkwhen gktrig, 0, 0, "CLICK", 0, 0.05
+endif
+endin
+
+; The GRAIN Instrument actually creates sounds
+instr 2, GRAIN
+iatk = 0.002
+igain = p5 * 0.075
+ipan = p6
+aenv = madsr:a(iatk, p3-iatk, 0, 0) * igain
+asig oscil aenv, cpsmidinn(scale(p4,110,55))
+asigL, asigR pan2 asig, ipan
+; outs asigL, asigR
+
+zawm asigL, gimixchL
+zawm asigR, gimixchR
+endin
+
+; The CLICK instrument creates a click event every time the metronome triggers
+; a restart
+instr 3, CLICK
+aenv = expseg(0.2, p3, 0.001)
+asig noise aenv, 0
+outs asig, asig
+endin
+
+; The MIX channel aggregates and limits the output volume.
+instr +MIX
+asigL zar gimixchL
+asigR zar gimixchR
+zacl gimixchL, gimixchR
+
+asigL limit asigL, -1, 1
+asigR limit asigR, -1, 1
+outs asigL, asigR
+endin
+
+</CsInstruments>
+<CsScore>
+</CsScore>
+</CsoundSynthesizer>

--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -21,6 +21,9 @@ function expcurve(x,y) {
     return (Math.exp(x * Math.log(y)) - 1) / (y-1)
 }
 
+const PLAY_TOGGLE_IDLE = false;
+const PLAY_TOGGLE_PLAYING = true;
+
 const kAttributeMappedProperties = [
     'time',
     'pitch'//,
@@ -576,11 +579,13 @@ const app = new Vue({
         },
         play() {
             if (!this.csoundReady) {
+                if (this.playToggle.state === PLAY_TOGGLE_PLAYING) this.playToggle.state = 0;
                 this.setUserMessage('Play aborted: csound not ready.');
                 return null;
             }
 
             if (!this.state.pitchAttribute || !this.state.timeAttribute) {
+                if (this.playToggle.state === PLAY_TOGGLE_PLAYING) this.playToggle.state = 0;
                 this.setUserMessage("Please set an attribute for time and pitch");
                 return null;
             }

--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -44,7 +44,7 @@ const app = new Vue({
     el: '#app',
     data: {
         name: 'Sonify',
-        version: 'v0.2.1',
+        version: 'v0.2.2',
         dim: {
             width: 325,
             height: 344

--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -1,7 +1,10 @@
 /*global codapInterface:true*/
 const helper = new CodapPluginHelper(codapInterface);
 const moveRecorder = new PluginMovesRecorder(helper);
-version of max and min in the argument list.
+/**
+ * Replicates the csound scale function.
+ * Scales a number between zero and one to the given range.
+ * Note the inversion of max and min in the argument list.
  **/
 function scale(v, max, min) {
     return (v * (max - min)) + min;

--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -286,7 +286,13 @@ const app = new Vue({
         updateTracker() {
             if (this.playing) {
                 let cyclePos = csound.RequestChannel('phase');
-                let dataTime = scale(cyclePos, this.timeAttrRange.max, this.timeAttrRange.min);
+                // For obscure reasons CODAP Time is measured in seconds,
+                // not milliseconds. Normally this adjustment is automatic.
+                // In order for the sonification tracker to align with the
+                // data we need to take this obscurity into account
+                let timeAdj = this.state.timeAttrIsDate? 1000: 1;
+                let dataTime = scale(cyclePos,
+                    this.timeAttrRange.max/timeAdj, this.timeAttrRange.min/timeAdj);
                 helper.setGlobal(trackingGlobalName, dataTime);
             }
         },

--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -46,7 +46,7 @@ const app = new Vue({
     el: '#app',
     data: {
         name: 'Sonify',
-        version: 'v0.2.2',
+        version: 'v0.2.3',
         dim: {
             width: 325,
             height: 344

--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -266,13 +266,13 @@ const app = new Vue({
                 });
             });
 
-            helper.on('dragDrop[attribute]', 'dragstart', (data) => {
+            helper.on('dragDrop[attribute]', 'dragstart', (/*data*/) => {
                 document.querySelectorAll('.drop-area').forEach(el => {
                     el.style.outline = '3px solid #ffff00';
                 })
             });
 
-            helper.on('dragDrop[attribute]', 'dragend', (data) => {
+            helper.on('dragDrop[attribute]', 'dragend', (/*data*/) => {
                 document.querySelectorAll('.drop-area').forEach(el => {
                     el.style.outline = '3px solid transparent';
                     el.style.backgroundColor = 'transparent';

--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -1,11 +1,7 @@
 /*global codapInterface:true*/
 const helper = new CodapPluginHelper(codapInterface);
 const moveRecorder = new PluginMovesRecorder(helper);
-
-/**
- * Replicates the csound scale function.
- * Scales a number between zero and one to the given range.
- * Note the inversion of max and min in the argument list.
+version of max and min in the argument list.
  **/
 function scale(v, max, min) {
     return (v * (max - min)) + min;
@@ -45,7 +41,7 @@ const app = new Vue({
     el: '#app',
     data: {
         name: 'Sonify',
-        version: 'v0.2.0',
+        version: 'v0.2.1',
         dim: {
             width: 325,
             height: 274

--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -41,7 +41,8 @@ const pitchMIDIRange = maxPitchMIDI - minPitchMIDI;
 const app = new Vue({
     el: '#app',
     data: {
-        name: 'Micro Rhythm',
+        name: 'Sonify',
+        version: 'v0.2.0',
         dim: {
             width: 325,
             height: 274
@@ -700,7 +701,7 @@ const app = new Vue({
         this.setupDrag();
         this.setupUI();
 
-        helper.init(this.name, this.dim)
+        helper.init(this.name, this.dim, this.version)
             // .then(helper.monitorLogMessages.bind(helper))
             .then((state) => {
                 if (state) {

--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -69,6 +69,8 @@ const app = new Vue({
             stereoAttrIsDate: false,
             stereoAttrIsDescending: false,
             playbackSpeed: 0.5,
+            loop: false,
+            click: false,
         },
         data: null,
         contexts: null, // array of context names
@@ -93,9 +95,6 @@ const app = new Vue({
         stereoAttrRange: null,
         stereoArray: [],
 
-        loop: false,
-        click: false,
-
         csdFiles: ['StableGrains.csd'],
         selectedCsd: null,
         csoundReady: false,
@@ -106,6 +105,8 @@ const app = new Vue({
         playing: false,
 
         speedSlider: null,
+        loopToggle: null,
+        clickToggle: null,
         userMessage: 'Select a dataset, pitch and time and click Play',
         timerId: null,
         phase: 0,
@@ -138,13 +139,13 @@ const app = new Vue({
                 }
             });
 
-            const loopToggle = new Nexus.Toggle('#loop-toggle', {
+            this.loopToggle = new Nexus.Toggle('#loop-toggle', {
                 size: [40, 20],
-                state: false,
+                state: this.state.loop,
             });
 
-            loopToggle.on('change', v => {
-                this.loop = v;
+            this.loopToggle.on('change', v => {
+                this.state.loop = v;
 
                 this.cycleEndTimerId && clearTimeout(this.cycleEndTimerId);
 
@@ -155,7 +156,7 @@ const app = new Vue({
                     gkfreq = scale(gkfreq, 5, 0.05);
                     const remainingPlaybackTime = (1 - phase) / gkfreq * 1000;
 
-                    if (this.loop) {
+                    if (this.state.loop) {
                         this.cycleEndTimerId = setTimeout(() => this.triggerNotes(0), remainingPlaybackTime);
                     } else {
                         this.cycleEndTimerId = setTimeout(() => {
@@ -168,14 +169,16 @@ const app = new Vue({
                 }
             });
 
-            let clickToggle = new Nexus.Toggle('#click-toggle', {
+            this.clickToggle = new Nexus.Toggle('#click-toggle', {
                 size: [40, 20],
-                state: false
+                state: this.state.click
             });
 
-            clickToggle.on('change', v => {
-                this.click = v;
-                csound.SetChannel('click', v ? 1 : 0);
+            this.clickToggle.on('change', v => {
+                this.state.click = v;
+                if (this.csoundReady) {
+                    csound.SetChannel('click', v ? 1 : 0);
+                }
             });
             this.speedSlider = new Nexus.Slider('#speed-slider', {
                 size: [200, 20],
@@ -187,7 +190,7 @@ const app = new Vue({
                 this.state.playbackSpeed = this.speedSlider._value.value;
 
                 if (this.csoundReady) {
-                    csound.SetChannel('playbackSpeed', v);
+                    csound.SetChannel('playbackSpeed', this.state.playbackSpeed);
 
                     if (this.playing) {
                         this.phase = csound.RequestChannel('phase');
@@ -540,7 +543,7 @@ const app = new Vue({
             gkfreq = scale(gkfreq, 5, 0.05);
 
             const remainingPlaybackTime = (1 - phase) / gkfreq * 1000;
-            if (this.loop) {
+            if (this.state.loop) {
                 this.cycleEndTimerId = setTimeout(() => this.triggerNotes(0), remainingPlaybackTime);
             } else {
                 this.cycleEndTimerId = setTimeout(() => {
@@ -569,7 +572,7 @@ const app = new Vue({
                 this.playing = true;
                 this.startTime = Date.now();
                 csound.SetChannel('playbackSpeed', this.state.playbackSpeed);
-                csound.SetChannel('click', this.click ? 1 : 0);
+                csound.SetChannel('click', this.state.click ? 1 : 0);
                 csound.Event(`i1 0 -1 ${this.phase}`)
 
                 this.timerId = setInterval(() => {
@@ -621,8 +624,14 @@ const app = new Vue({
             Object.keys(state).forEach(key => {
                 this.state[key] = state[key];
             });
-            if (this.state.playbackSpeed) {
+            if (this.state.playbackSpeed != null) {
                 this.speedSlider.value = this.state.playbackSpeed;
+            }
+            if (this.state.loop != null) {
+                this.loopToggle.state = this.state.loop;
+            }
+            if (this.state.click != null) {
+                this.clickToggle.state = this.state.click;
             }
             helper.queryAllData().then(this.onGetData).then(() =>{
                 if (this.state.focusedContext) {

--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -507,8 +507,13 @@ const app = new Vue({
                     const halfDur = (duration * durRange + minDur) / 2;
                     pitchTimeMap[pitchID] = (d.val / gkfreq) + halfDur;
 
+                    // Prepend with zeros to prevent overlapping note IDs.
+                    // Instead of, e.g., 1.1, 1.2, ..., 1.10 (a duplicate ID),
+                    // we will have 1.00001, 1.00002, ..., 1.00010, etc.
+                    const noteID = d.id.toString().padStart(5, 0) // Max 10^5 data points.
+
                     if (![d.val,pitch,duration,loudness,stereo].some(isNaN)) {
-                        csound.Event(`i 1.${d.id} 0 -1 ${d.val} ${duration} ${pitch} ${loudness} ${stereo}`);
+                        csound.Event(`i 1.${noteID} 0 -1 ${d.val} ${duration} ${pitch} ${loudness} ${stereo}`);
                     }
                 }
             });
@@ -553,6 +558,7 @@ const app = new Vue({
 
             this.timerId && clearInterval(this.timerId);
             csound.Stop();
+            csound.Csound.reset(); // Ensure the playback position, etc. are reset.
             this.playing = false;
             pitchTimeMap = {};
         },

--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -415,6 +415,11 @@ const app = new Vue({
             if (this.state.focusedContext) {
                 this.attributes = helper.getAttributesForContext(this.state.focusedContext);
                 this.reselectCases();
+                kAttributeMappedProperties.forEach(p => {
+                    if (this[p + 'AttrRange']) {
+                        this.processMappedAttribute(p);
+                    }
+                })
             }
         },
         onGetGlobals() {
@@ -684,8 +689,10 @@ const app = new Vue({
                         if (contextName === this.state.focusedContext) {
                             helper.getSelectedItems(this.state.focusedContext).then(this.onItemsSelected);
                         }
-                    } else {
-                        helper.queryDataForContext(contextName).then(this.onGetData);
+                    } else if (operation === 'createCases' || operation === 'deleteCases' || operation === 'updateCases') {
+                        if (contextName === this.state.focusedContext) {
+                            helper.queryDataForContext(contextName).then(this.onGetData);
+                        }
                     }
                 }
 

--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -47,7 +47,7 @@ const app = new Vue({
     el: '#app',
     data: {
         name: 'Sonify',
-        version: 'v0.2.3',
+        version: 'v0.2.4',
         dim: {
             width: 285,
             height: 385

--- a/Sonification/MicroRhythm/index.html
+++ b/Sonification/MicroRhythm/index.html
@@ -179,6 +179,9 @@
 <!--                </select>-->
 <!--            </label>-->
 <!--        </div>-->
+        <div class="mapper-container">
+            <button :disabled="!isPlayable" v-on:click="createGraph">create graph</button>
+        </div>
     </div>
     <div id="footer-container">
         <img id="info-icon" src="../images/Icon-round-Question_mark.svg" alt="Information" title="Information" draggable="false" @click="openInfoPage">

--- a/Sonification/MicroRhythm/index.html
+++ b/Sonification/MicroRhythm/index.html
@@ -76,9 +76,9 @@
                 <label title="Whether the attribute controlling pitch has date/time values or is numeric">
                     <input type="checkbox" v-model="state.pitchAttrIsDate" v-on:change="onPitchAttributeSelectedByUI"> DateTime
                 </label>
-                <label title="Whether to pitch should descend or ascend when attribute increases">
-                    <input type="checkbox" v-model="state.pitchAttrIsDescending" v-on:change="onPitchAttributeSelectedByUI"> Descending
-                </label>
+<!--                <label title="Whether to pitch should descend or ascend when attribute increases">-->
+<!--                    <input type="checkbox" v-model="state.pitchAttrIsDescending" v-on:change="onPitchAttributeSelectedByUI"> Descending-->
+<!--                </label>-->
             </div>
         </div>
 

--- a/Sonification/MicroRhythm/index.html
+++ b/Sonification/MicroRhythm/index.html
@@ -28,6 +28,10 @@
                 <label for="play-toggle">Play</label>
                 <span id="play-toggle"></span>
             </div>
+            <div class="controller-container" title="Enable playback looping">
+                <label for="loop-toggle">Loop</label>
+                <span id="loop-toggle"></span>
+            </div>
             <div class="controller-container" title="Enable periodic click sound">
                 <label for="click-toggle">Click</label>
                 <span id="click-toggle"></span>

--- a/Sonification/MicroRhythm/index.html
+++ b/Sonification/MicroRhythm/index.html
@@ -179,6 +179,15 @@
 <!--                </select>-->
 <!--            </label>-->
 <!--        </div>-->
+        <div class="mapper-container" title="Select case-selection mode">
+            Case selection mode
+            <label>
+                <select v-model="state.selectionMode" v-on:change="onSelectionModeSelectedByUI">
+                    <option disabled value="" hidden>Select</option>
+                    <option v-for="mode in selectionModes">{{mode}}</option>
+                </select>
+            </label>
+        </div>
         <div class="mapper-container">
             <button :disabled="!isPlayable" v-on:click="createGraph">create graph</button>
         </div>

--- a/Sonification/MicroRhythm/info.md
+++ b/Sonification/MicroRhythm/info.md
@@ -1,31 +1,56 @@
-# Micro Rhythm
-This sonification plugin creates micro-tonal and micro-rhythmic melodies from data.
+# Sonify
+This plugin creates microtonal and microrhythmic melodies from data.
 
 ## Basic usage
 0. Before turning on, lower the volume of the speaker / headphones to avoid a sudden blast of sound.
-1. Toggle the Play switch.
-2. Assign CODAP attributes to the Pitch and Time dimensions using the drop-down menu or drag and drop.
-- The plugin accepts numeric as well as date values. If the attribute is in a date format, you need to tick the "DateTime" box.
-- You may want to create an accompanying visual graph with the Time attribute mapped to X axis, and the Pitch attribute to Y axis.
-3. Select some data points in CODAP to play.
-4. The melodic pattern repeats endlessly. Toggle Click to hear the starting (i.e., ending) location in time.
+1. Assign CODAP attributes to the Pitch and Time dimensions using the drop-down menu or drag and drop.
+- The plugin accepts numeric as well as date values. If the attribute is in a date format, check that the "DateTime" box is ticked.
+- You may want to create an accompanying visual graph with the Time attribute mapped to X axis, and the Pitch attribute to Y axis. You can do this manually or you can press the "create graph" button.
+2. Toggle the Play switch to play sounds. 
+- Data points thar are selected in CODAP have a more prominent sound.
+3. You can make the melodic pattern repeat endlessly by toggling the "Loop" switch. 
+4. Toggle Click to hear the starting (i.e., ending) location in time.
 - For the attribute mapped to Time, you should hear sounds with the earlier in time, the lower the mapped value.
 - For the Pitch attribute, the higher the pitch, the higher the value (unless you tick the Descending mode).
 
 ## Concepts
-Unlike the melodies or rhythms in traditional Western music that have distinct beats (e.g., quarter notes) and familiar musical scales (e.g., major scale), this sonification creates continuous and more granular melodies / sounds. In audio-synthesis technologies, this micro-timing synthesis technique is usually called the [granular synthesis](http://granularsynthesis.com/guide.php). Each data point is represented by a very short sound with a unique pitch, placed in a cyclic timeline. Depending on the data mapped to the time, you might hear a smooth line of melody, a rhythmic pattern, a harmonic texture, or a random noise.
+Unlike the melodies or rhythms in traditional Western music that have distinct 
+beats (e.g., quarter notes) and familiar musical scales (e.g., major scale), 
+this sonification creates continuous and more granular melodies / sounds. 
+In audio-synthesis technologies, this micro-timing synthesis technique is 
+usually called the [granular synthesis](http://granularsynthesis.com/guide.php). 
+Each data point is represented by a very short sound with a unique pitch, 
+placed in a timeline. Depending on the data mapped to the time, 
+you might hear a smooth line of melody, a rhythmic pattern, a harmonic texture, 
+or a random noise.
 
 ## Things to try
 ### Time series vs non time series
-Since Micro Rhythm sequence streams over time similar to time series data, it might easily make sense to map the time/date to the Time parameter (don't forget to tick the "Datetime" mode on). You then have the time-stretched or compressed melody that evolves over time.
+Since the plugin sequence streams over time similar to time series data, 
+it might make sense to map the time/date to the Time parameter 
+You then have the time-stretched or compressed melody that evolves over time.
 
-What would happen if you flip the mappings between Time and Pitch? Now the pitch goes higher as the original time/date progresses, but the timestamped event happens sooner in the melody if it has a low measurement mapped to Time, and later if it has a high value (you could invert it).
+What would happen if you flip the mappings between Time and Pitch? 
+Now the pitch goes higher as the original time/date progresses, 
+but the timestamped event happens sooner in the melody if it has a low 
+measurement mapped to Time, and later if it has a high value.
 
 ### Correlated variables
-When you map the same attribute to Pitch and Time, what should it sound like? Try finding attributes that have rising or falling patterns. You can also try calculating the linear-regression line with attribute formula, and hear what kind of slope / correlation it produces.
+When you map the same attribute to Pitch and Time, what should it sound like? 
+Try finding attributes that have rising or falling patterns. 
+You can also try calculating the linear-regression line with attribute formula, 
+and hear what kind of slope / correlation it produces.
 
 ### Sorted sequence (by case index)
-Create a new attribute with the formula `caseIndex`. Map this attribute to Time. Now, try sorting the cases by various attributes / sorting rules.
+Create a new attribute with the formula `caseIndex`. 
+Map this attribute to Time. 
+Now, try sorting the cases by various attributes / sorting rules.
 
 ### Random sampling
-Create a new attribute with the formula `random()`. Map this attribute to Time. By default, this creates a complex rhythm with fractional time intervals. However, if you combine this with the above "Sort by case index" technique, you can hear the values at a steady rate. You can also try rounding (binning) the fractional time values into fixed intervals by a formula `floor(attr*resolution)`.
+Create a new attribute with the formula `random()`. 
+Map this attribute to Time. By default, 
+this creates a complex rhythm with fractional time intervals. 
+However, if you combine this with the above "Sort by case index" technique, 
+you can hear the values at a steady rate. 
+You can also try rounding (binning) the fractional time values into fixed 
+intervals by a formula `floor(attr*resolution)`.

--- a/Sonification/lib/CodapPluginHelper.js
+++ b/Sonification/lib/CodapPluginHelper.js
@@ -38,6 +38,8 @@ class CodapPluginHelper {
         // this.createCasesPromise = null; // Somehow reusing the same promise can result in multiple resolve calls.
         this.createCasesResolve = null;
         this.caseTimerDuration = 1000;
+
+        this.documentAnnotator = null;
     }
 
     init(name, dimensions={width:200,height:100}, version) {
@@ -61,11 +63,15 @@ class CodapPluginHelper {
                 this.ID = pluginState.ID = new Date().getTime();
             }
 
+            // set up document listener
+            this.on('document', null, (msg) => { this.handleNewDocumentNotification(msg); });
+
             if (!hasState) {
                 return this.codapInterface.sendRequest({
                     action: "update",
                     resource: "interactiveFrame",
                     values: {
+                        subscribeToDocuments: true,
                         dimensions: {
                             width: dimensions.width,
                             height: dimensions.height + 25
@@ -76,6 +82,7 @@ class CodapPluginHelper {
                 return this.queryAllData();
             }
             // Allow the attributes to move.
+
         })
         .then( () => {return this.getPluginID(); })
         .then(id=> {this.pluginID = id;})
@@ -628,6 +635,37 @@ class CodapPluginHelper {
 
     }
 
+    /**
+     * fetches the CODAP document, calls the annotationHandler, then returns
+     * the changed document as an update. This is obviously a very dangerous
+     * operation and should be used with extreme care.
+     */
+    annotateDocument(annotationHandler) {
+        this.documentAnnotator = annotationHandler;
+        this.codapInterface.sendRequest(
+            {
+                action: 'get',
+                resource: `document`
+            });
+
+    }
+
+    handleNewDocumentNotification(msg) {
+        if (this.documentAnnotator && msg && msg.values) {
+            let doc = this.documentAnnotator(msg.values.state);
+            this.documentAnnotator = null;
+            if (doc) {
+                this.codapInterface.sendRequest({
+                    action: 'update',
+                    resource: 'document',
+                    values: doc
+                })
+            }
+        }
+    }
+
+
+
     // openInfoPage(dimensions, name, file) {
     //     let location = window.location.pathname;
     //     let directory = location.substring(0, location.lastIndexOf('/'));
@@ -722,6 +760,18 @@ class CodapPluginHelper {
         });
     }
 
+    createGraph(dataContext, xAxis, yAxis) {
+        return this.codapInterface.sendRequest({
+            action: 'create',
+            resource: 'component',
+            values: {
+                type: 'graph',
+                dataContext: dataContext,
+                xAttributeName: xAxis,
+                yAttributeName: yAxis
+            }
+        })
+    }
 
     selectSelf() {
         if (this.pluginID) {

--- a/Sonification/lib/CodapPluginHelper.js
+++ b/Sonification/lib/CodapPluginHelper.js
@@ -594,6 +594,36 @@ class CodapPluginHelper {
         });
     }
 
+    guaranteeGlobal(name) {
+        return this.codapInterface.sendRequest({
+            action: 'get',
+            resource: `global[${name}]`
+        }).then (result => {
+            if (!result.success) {
+                return this.codapInterface.sendRequest({
+                    action: 'create',
+                    resource: 'global',
+                    values: {
+                        name: name,
+                        value: 0
+                    }
+                });
+            } else {
+                return result;
+            }
+        })
+    }
+
+    setGlobal(name, value) {
+        return this.codapInterface.sendRequest({
+            action: 'update',
+            resource: `global[${name}]`,
+            values: {
+                value: value
+            }
+        });
+    }
+
     findCollectionForAttribute() {
 
     }

--- a/Sonification/lib/CodapPluginHelper.js
+++ b/Sonification/lib/CodapPluginHelper.js
@@ -543,6 +543,10 @@ class CodapPluginHelper {
         return (this.items && Object.keys(this.items).length) ? this.items[context].map(c => c.values[attribute]) : null;
     }
 
+    /**
+     * Returns the items corresponding to the cases selected by the user.
+     * When no cases are selected, all the case are returned as "selected."
+     */
     getSelectedItems(context) {
         return this.codapInterface.sendRequest({
             action: 'get',
@@ -552,13 +556,35 @@ class CodapPluginHelper {
             let selectedItems;
             if (caseIDs.length) {
                 selectedItems = caseIDs
-                    .map(id => this.items[context]
-                        .find(item => item && item.id === id));// item.id is actually the case ID.
+                    .map(id => {
+                        // item.id is actually the case ID.
+                        return this.items[context]
+                            .find(item => item && item.id === id)
+                    });
             } else {
                 selectedItems = this.items[context];
             }
-            return selectedItems
-                .filter(item => typeof(item) !== 'undefined');
+            return selectedItems.filter(item => typeof(item) !== 'undefined');
+        });
+    }
+
+    /**
+     * Return the selected items. When no cases are selected,
+     * return an empty array rather than all the cases.
+     */
+    getStrictlySelectedItems(context) {
+        return this.codapInterface.sendRequest({
+            action: 'get',
+            resource: `dataContext[${context}].selectionList`
+        }).then(result => {
+            let caseIDs = result.values.map(v => v.caseID);
+            return caseIDs
+                .map(id => {
+                    // item.id is actually the case ID.
+                    return this.items[context]
+                        .find(item => item && item.id === id)
+                })
+                .filter(item => item !== 'undefined');
         });
     }
 

--- a/Sonification/lib/CodapPluginHelper.js
+++ b/Sonification/lib/CodapPluginHelper.js
@@ -636,11 +636,19 @@ class CodapPluginHelper {
     }
 
     /**
-     * fetches the CODAP document, calls the annotationHandler, then returns
-     * the changed document as an update. This is obviously a very dangerous
-     * operation and should be used with extreme care.
+     * Initiates the "get document" process.
+     *
+     * The get/document API call causes the document to be set, not in the
+     * reply, but in a subsequent notification. We set, in this call the
+     * annotationHandler that will be called by this.handleNewDocumentNotification()
+     * upon receipt of a notification. The handler will be invoked once.
+     * The annotationHandler should return a new version of the document.
+     * If it does so, this will be sent as an update to CODAP.
      */
     annotateDocument(annotationHandler) {
+        if (this.documentAnnotator && annotationHandler) {
+            console.warn(`Unexpected overwrite of CodapPluginHandler.documentHandler`)
+        }
         this.documentAnnotator = annotationHandler;
         this.codapInterface.sendRequest(
             {


### PR DESCRIPTION
This PR has two main changes:
1. Restores the ability to open an existing document with assignments to pitch and time fields as they were when the document was saved,
2. Fixes bugs affecting positioning of the sonificationTracker in graphs. There were several issues. The way the graph component in CODAP decides whether an axis is a time axis varied from the plugin, so this fix aligns the plugin to the graph's rule. The initial value of the sonificationTracker global value wasn't being set in various circumstances.

I noticed that the code was no longer paying attention to user modification of the DateTime checkbox. There didn't seem to be a meaningful use case where the plugin should pay attention to this, so I made the checkbox read only.