### PR TITLE
Tracker visible on create

### DIFF
--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -796,7 +796,7 @@ const app = new Vue({
                                 adornments.plottedValue = {
                                         "isVisible": true,
                                         "adornmentKey": "plottedValue",
-                                        "expression": "sonificationTracker"
+                                        "expression": trackingGlobalName
                                     };
                                 adornments.connectingLine = {isVisible: true};
 

--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -689,7 +689,7 @@ const app = new Vue({
             }
             helper.queryAllData().then(this.onGetData).then(() =>{
                 if (this.state.focusedContext) {
-                    this.onContextFocused();
+                    this.attributes = helper.getAttributesForContext(this.state.focusedContext);
                 }
                 kAttributeMappedProperties.forEach( (p) => {
                     if (this.state[p + 'Attribute']) {this.processMappedAttribute(p);}

--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -313,7 +313,7 @@ const app = new Vue({
         setIfDateTimeAttribute(type) {
             let contextName = this.state.focusedContext;
             let attrName = this.state[`${type}Attribute`];
-            let values = helper.getAttrValuesForContext(contextName, attrName);
+            let values = helper.getAttrValuesForContext(contextName, attrName) || [];
             // an attribute is a Date attribute if none of its values are non-dates
             let isDateAttribute = !values.some((x) => {
                 let isDate = (x instanceof Date) ||

--- a/Sonification/MicroRhythm/app.js
+++ b/Sonification/MicroRhythm/app.js
@@ -47,7 +47,7 @@ const app = new Vue({
     el: '#app',
     data: {
         name: 'Sonify',
-        version: 'v0.2.4',
+        version: 'v0.2.5',
         dim: {
             width: 285,
             height: 385

--- a/Sonification/MicroRhythm/index.html
+++ b/Sonification/MicroRhythm/index.html
@@ -74,7 +74,7 @@
 
             <div>
                 <label title="Whether the attribute controlling pitch has date/time values or is numeric">
-                    <input type="checkbox" v-model="state.pitchAttrIsDate" v-on:change="onPitchAttributeSelectedByUI"> DateTime
+                    <input type="checkbox" v-model="state.pitchAttrIsDate" disabled="true"  v-on:change="onPitchAttributeSelectedByUI"> DateTime
                 </label>
 <!--                <label title="Whether to pitch should descend or ascend when attribute increases">-->
 <!--                    <input type="checkbox" v-model="state.pitchAttrIsDescending" v-on:change="onPitchAttributeSelectedByUI"> Descending-->
@@ -95,7 +95,7 @@
 
             <div>
                 <label title="Whether the time attribute has date/time values or numeric values">
-                    <input type="checkbox" v-model="state.timeAttrIsDate" v-on:change="onTimeAttributeSelectedByUI"> DateTime
+                    <input type="checkbox" v-model="state.timeAttrIsDate" disabled="true" v-on:change="onTimeAttributeSelectedByUI"> DateTime
                 </label>
 <!--                <label title="Whether to reverse the order of sample play">-->
 <!--                    <input type="checkbox" v-model="state.timeAttrIsDescending" v-on:change="onTimeAttributeSelectedByUI"> Descending-->

--- a/Sonification/lib/CodapPluginHelper.js
+++ b/Sonification/lib/CodapPluginHelper.js
@@ -540,7 +540,7 @@ class CodapPluginHelper {
     }
 
     getAttrValuesForContext(context, attribute) {
-        return (this.items && Object.keys(this.items).length) ? this.items[context].map(c => c.values[attribute]) : null;
+        return (this.items && this.items[context] && Object.keys(this.items).length) ? this.items[context].map(c => c.values[attribute]) : null;
     }
 
     /**
@@ -552,17 +552,22 @@ class CodapPluginHelper {
             action: 'get',
             resource: `dataContext[${context}].selectionList`
         }).then(result => {
-            let caseIDs = result.values.map(v => v.caseID);
             let selectedItems;
-            if (caseIDs.length) {
-                selectedItems = caseIDs
-                    .map(id => {
-                        // item.id is actually the case ID.
-                        return this.items[context]
-                            .find(item => item && item.id === id)
-                    });
-            } else {
-                selectedItems = this.items[context];
+            if (result.success) {
+                let caseIDs = result.values.map(v => v.caseID);
+                if (caseIDs.length) {
+                    selectedItems = caseIDs
+                        .map(id => {
+                            // item.id is actually the case ID.
+                            return this.items[context]
+                                .find(item => item && item.id === id)
+                        });
+                } else {
+                    selectedItems = this.items[context];
+                }
+            }
+            else {
+                selectedItems = [];
             }
             return selectedItems.filter(item => typeof(item) !== 'undefined');
         });

--- a/Sonification/lib/CodapPluginHelper.js
+++ b/Sonification/lib/CodapPluginHelper.js
@@ -590,6 +590,7 @@ class CodapPluginHelper {
             action: 'get',
             resource: `dataContext[${context}].selectionList`
         }).then(result => {
+            if (!result.success) return [];
             let caseIDs = result.values.map(v => v.caseID);
             return caseIDs
                 .map(id => {

--- a/Sonification/lib/CodapPluginHelper.js
+++ b/Sonification/lib/CodapPluginHelper.js
@@ -79,7 +79,15 @@ class CodapPluginHelper {
                     }
                 }).then(() => this.queryAllData());
             } else {
-                return this.queryAllData();
+                return this.codapInterface.sendRequest({
+                    action: "update",
+                    resource: "interactiveFrame",
+                    values: {
+                        subscribeToDocuments: true
+                    }
+                }).then(() =>
+                    this.queryAllData()
+                );
             }
             // Allow the attributes to move.
 


### PR DESCRIPTION
Taka,
I am so sorry. I screwed up (again) on creating the pull request. I missread the options and the effect of the last pull request was to merge the branch 'work' into the branch 'master' on my fork. I meant to merge the branch 'tracker-visible-on-create', which has the current changes. I know you are heading on vacation, but I hope I have caught you in time. 

To reiterate the description of the changes:


This PR has two main changes:

1. Restores the ability to open an existing document with assignments to pitch and time fields as they were when the document was saved,
2. Fixes bugs affecting positioning of the sonificationTracker in graphs. There were several issues. The way the graph component in CODAP decides whether an axis is a time axis varied from the plugin, so this fix aligns the plugin to the graph's rule. The initial value of the sonificationTracker global value wasn't being set in various circumstances.

I noticed that the code was no longer paying attention to user modification of the DateTime checkbox. There didn't seem to be a meaningful use case where the plugin should pay attention to this, so I made the checkbox read only.
